### PR TITLE
Remove System.register from UMD header

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Draccoz/tslib.git"
+    "url": "https://github.com/Microsoft/tslib.git"
   },
   "main": "tslib.js",
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "Microsoft Corp."
   ],
   "homepage": "http://typescriptlang.org/",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "Apache License 2.0",
   "description": "Runtime library for TypeScript helper functions",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tslib",
     "author": "Microsoft Corp.",
     "homepage": "http://typescriptlang.org/",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "licenses": [
         {
             "type": "Apache License 2.0",

--- a/tslib.js
+++ b/tslib.js
@@ -23,13 +23,7 @@ var __awaiter;
 var __generator;
 (function (factory) {
     var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
-    if (typeof System === "object" && typeof System.register === "function") {
-        System.register("tslib", [], function (exporter) {
-            factory(createExporter(root, exporter));
-            return { setters: [], execute: function() { } };
-        });
-    }
-    else if (typeof define === "function" && define.amd) {
+    if (typeof define === "function" && define.amd) {
         define("tslib", ["exports"], function (exports) { factory(createExporter(root, createExporter(exports))); });
     }
     else if (typeof module === "object" && typeof module.exports === "object") {
@@ -38,7 +32,6 @@ var __generator;
     else {
         factory(createExporter(root));
     }
-
     function createExporter(exports, previous) {
         return function (id, v) { return exports[id] = previous ? previous(id, v) : v; };
     }


### PR DESCRIPTION
This PR removes `System.register` from the UMD header of tslib.js in favor of System's built in [module format detection](https://github.com/systemjs/systemjs/blob/master/docs/module-formats.md#module-format-detection). This fixes an issue with how tslib.js loads when running inside of JSPM/SystemJS.

Fixes: https://github.com/Microsoft/TypeScript/issues/12887