### PR TITLE
chore: update package.json and bower.json with valid SPDX identifiers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   ],
   "homepage": "http://typescriptlang.org/",
   "version": "1.6.0",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "description": "Runtime library for TypeScript helper functions",
   "keywords": [
     "TypeScript",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
     "author": "Microsoft Corp.",
     "homepage": "http://typescriptlang.org/",
     "version": "1.6.0",
-    "licenses": [
-        {
-            "type": "Apache License 2.0",
-            "url": "https://github.com/Microsoft/tslib/blob/master/LICENSE.txt"
-        }
-    ],
+    "license": "Apache-2.0",
     "description": "Runtime library for TypeScript helper functions",
     "keywords": [
         "TypeScript",


### PR DESCRIPTION
This PR adds the valid SPDX identifier for the Apache 2.0 license to both the `bower.json` and `package.json` license field.

You can read more about SPDX here, in case this is unknown:
https://spdx.org/about

The npm docs state that the license should be an SPDX identifier in the license (singular!) field:
https://docs.npmjs.com/files/package.json#license

Same for bower:
https://github.com/bower/spec/blob/master/json.md#license