### PR TITLE
support node ESModules via --experimental-modules flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+tslib.mjs

--- a/package.json
+++ b/package.json
@@ -21,7 +21,23 @@
         "type": "git",
         "url": "https://github.com/Microsoft/tslib.git"
     },
-    "main": "tslib.js",
+    "files": [
+        "CopyrightNotice.txt",
+        "README.md",
+        "docs",
+        "tslib.d.ts",
+        "tslib.es6.js",
+        "tslib.js",
+        "LICENSE.txt",
+        "bower.json",
+        "tslib.es6.html",
+        "tslib.html",
+        "tslib.mjs"
+    ],
+    "scripts": {
+        "prepublishOnly": "cp tslib.es6.js tslib.mjs"
+    },
+    "main": "tslib",
     "module": "tslib.es6.js",
     "jsnext:main": "tslib.es6.js",
     "typings": "tslib.d.ts"


### PR DESCRIPTION
This PR adds support for importing `tslib` in node running with the `--experimental-modules` flag:

1. Adds a "prepublishOnly" script to copy `tslib.es6.js` to `tslib.mjs` just before publishing to npm (not windows compatible afaik -- wanted to avoid adding an `shx` devDependency)
2. Removes the file extension from the `"main": "tslib.js"` package.json entry
3. Adds a "files" entry in package.json
4. Add "tslib.mjs" entry to .gitignore

Steps 1-2 are necessary because node will automatically select either the "js" or "mjs" file depending on whether it was run with the --experimental-modules flag, but only if the "main" entry doesn't explicitly specify a file extension.

Step 3 ensures the gitignore'd `tslib.mjs` file is included in the assets published to npm.
Step 4 ensures the `mjs` file is always in line with the `tslib.es6.js` file, and avoids source code duplication.

### ESModules in node >= 8.6.0

If you attempt to import a CommonJS module as an ESModule (either by explicitly importing the "js" version, or if there's no explicit extension and no "mjs" file available), node will synthesize a default export from the "module.exports" object, leading to the following error condition:

```js
// $ node index.js
const tslib = require('tslib');
// works like normal
tslib_1.__awaiter(/* some code generated by TypeScript */);
```
```js
// $ node --experimental-modules index.mjs
import * as tslib from 'tslib';
// throws "TypeError: tslib_1.__awaiter is not a function"
tslib_1.__awaiter(/* some code generated by TypeScript */);
```
<img width="518" alt="screen shot 2017-11-20 at 1 06 41 pm" src="https://user-images.githubusercontent.com/178183/33041634-da943bd2-cdf3-11e7-9af0-d4dc098f4f52.png">

I believe this PR is the less invasive of two possible approaches, as it shouldn't break anyone who has hard-coded references to `tslib.es6.js` in their builds (e.g. for closure compiler). Alternatively, we could rename `tslib.es6.js` -> `tslib.mjs` ([branch](https://github.com/trxcllnt/tslib/commit/a62adcda72c455ed55dacb0b8afa511aabff2967)).

For context: the [Apache Arrow](https://github.com/apache/arrow) JS project is written in TypeScript, and we're targeting full compatibility with node's new --experimental-modules flag.

The last step in our upgrade process is helping ensure our dependencies expose node v8.6.0+ compatible ESModules. Please let me know if there's anything else I can do to help get this PR accepted, and a new version published soon. Thanks!