### PR TITLE
Add 'tslib.umd.js' to avoid global pollution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+src
+scripts

--- a/CopyrightNotice.txt
+++ b/CopyrightNotice.txt
@@ -1,15 +1,14 @@
 /*! *****************************************************************************
-Copyright (c) Microsoft Corporation. All rights reserved. 
+Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the
-License at http://www.apache.org/licenses/LICENSE-2.0  
- 
+License at http://www.apache.org/licenses/LICENSE-2.0
+
 THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, 
-MERCHANTABLITY OR NON-INFRINGEMENT. 
- 
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+    "name": "tslib",
+    "version": "1.9.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "6.0.110",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
+            "integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "2.9.0-dev.20180512",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.0-dev.20180512.tgz",
+            "integrity": "sha512-IoShsqB7aix2NsKnaKqlCuerZdWp0OHIrWufUY2mfV1vDf8FTmBA49AODKbWySTQCi2YBB6SGqih9FLMEBjZJA==",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
         "tslib",
         "runtime"
     ],
+    "scripts": {
+        "build-generator": "tsc scripts/generator.ts --module commonjs --target es2015",
+        "build": "npm run build-generator && node scripts/generator.js src ."
+    },
     "bugs": {
         "url": "https://github.com/Microsoft/TypeScript/issues"
     },
@@ -21,8 +25,12 @@
         "type": "git",
         "url": "https://github.com/Microsoft/tslib.git"
     },
-    "main": "tslib.js",
+    "main": "tslib.umd.js",
     "module": "tslib.es6.js",
     "jsnext:main": "tslib.es6.js",
-    "typings": "tslib.d.ts"
+    "typings": "tslib.d.ts",
+    "devDependencies": {
+        "@types/node": "^6.0.110",
+        "typescript": "^2.9.0-dev.20180512"
+    }
 }

--- a/scripts/generator.js
+++ b/scripts/generator.js
@@ -1,0 +1,257 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const rootDir = path.resolve(__dirname, `..`);
+const srcDir = path.resolve(rootDir, `src`);
+const copyrightNotice = fs.readFileSync(path.resolve(rootDir, "CopyrightNotice.txt"), "utf8");
+const umdGlobalsExporter = fs.readFileSync(path.resolve(srcDir, "umdGlobals.js"), "utf8");
+const umdExporter = fs.readFileSync(path.resolve(srcDir, "umd.js"), "utf8");
+const tslibFile = path.resolve(srcDir, "tslib.js");
+const indentStrings = ["", "    "];
+const MAX_SMI_X86 = 1073741823;
+class TextWriter {
+    constructor() {
+        this.indent = 0;
+        this.output = "";
+        this.pendingNewLines = 0;
+    }
+    write(s) {
+        if (s && s.length) {
+            this.writePendingNewLines();
+            this.output += s;
+        }
+    }
+    writeLine(s) {
+        this.write(s);
+        this.pendingNewLines++;
+    }
+    writeLines(s) {
+        if (s) {
+            const lines = s.split(/\r\n?|\n/g);
+            const indentation = guessIndentation(lines);
+            for (const lineText of lines) {
+                const line = indentation ? lineText.slice(indentation) : lineText;
+                if (!this.pendingNewLines && this.output.length > 0) {
+                    this.writeLine();
+                }
+                this.writeLine(line);
+            }
+        }
+    }
+    toString() {
+        return this.output;
+    }
+    writePendingNewLines() {
+        if (this.pendingNewLines > 0) {
+            do {
+                this.output += "\n";
+                this.pendingNewLines--;
+            } while (this.pendingNewLines > 0);
+            this.output += getIndentString(this.indent);
+        }
+    }
+}
+main();
+function main() {
+    const sourceFiles = parseSources();
+    generateSingleFileVariations(sourceFiles, rootDir);
+}
+function getIndentString(level) {
+    if (indentStrings[level] === undefined) {
+        indentStrings[level] = getIndentString(level - 1) + indentStrings[1];
+    }
+    return indentStrings[level];
+}
+function guessIndentation(lines) {
+    let indentation = MAX_SMI_X86;
+    for (const line of lines) {
+        if (!line.length) {
+            continue;
+        }
+        let i = 0;
+        for (; i < line.length && i < indentation; i++) {
+            if (!/^[\s\r\n]/.test(line.charAt(i))) {
+                break;
+            }
+        }
+        if (i < indentation) {
+            indentation = i;
+        }
+        if (indentation === 0) {
+            return 0;
+        }
+    }
+    return indentation === MAX_SMI_X86 ? undefined : indentation;
+}
+function mkdirpSync(dir) {
+    try {
+        fs.mkdirSync(dir);
+    }
+    catch (e) {
+        if (e.code === "EEXIST")
+            return;
+        if (e.code === "ENOENT") {
+            const parent = path.dirname(dir);
+            if (parent && parent !== dir) {
+                mkdirpSync(parent);
+                fs.mkdirSync(dir);
+                return;
+            }
+        }
+        throw e;
+    }
+}
+function parse(file) {
+    const sourceText = fs.readFileSync(file, "utf8");
+    const sourceFile = ts.createSourceFile(file, sourceText, ts.ScriptTarget.ES3, /*setParentNodes*/ true, ts.ScriptKind.JS);
+    return sourceFile;
+}
+function parseSources() {
+    const sourceFiles = [];
+    sourceFiles.push(parse(tslibFile));
+    return sourceFiles;
+}
+function generateSingleFileVariations(sourceFiles, outDir) {
+    generateSingleFile(sourceFiles, path.resolve(outDir, "tslib.js"), 1 /* UmdGlobal */);
+    generateSingleFile(sourceFiles, path.resolve(outDir, "tslib.umd.js"), 0 /* Umd */);
+    generateSingleFile(sourceFiles, path.resolve(outDir, "tslib.es6.js"), 2 /* ES2015 */);
+}
+function generateSingleFile(sourceFiles, outFile, libKind) {
+    const bundle = ts.createBundle(sourceFiles);
+    const output = write(bundle, libKind);
+    mkdirpSync(path.dirname(outFile));
+    fs.writeFileSync(outFile, output, "utf8");
+}
+function formatMessage(node, message) {
+    const sourceFile = node.getSourceFile();
+    if (sourceFile) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        return `${sourceFile.fileName}(${line + 1}, ${character + 1}): ${message}`;
+    }
+    return message;
+}
+function reportError(node, message) {
+    console.error(formatMessage(node, message));
+}
+function write(source, libKind) {
+    const globalWriter = new TextWriter();
+    const bodyWriter = new TextWriter();
+    const exportWriter = new TextWriter();
+    let sourceFile;
+    return writeBundle(source);
+    function writeBundle(node) {
+        switch (libKind) {
+            case 0 /* Umd */:
+            case 1 /* UmdGlobal */:
+                return writeUmdBundle(node);
+            case 2 /* ES2015 */:
+                return writeES2015Bundle(node);
+        }
+    }
+    function writeUmdBundle(node) {
+        visit(node);
+        const writer = new TextWriter();
+        writer.writeLines(copyrightNotice);
+        writer.writeLines(globalWriter.toString());
+        writer.writeLines(libKind === 1 /* UmdGlobal */ ? umdGlobalsExporter : umdExporter);
+        writer.writeLine(`(function (exporter) {`);
+        writer.indent++;
+        writer.writeLines(bodyWriter.toString());
+        writer.writeLine();
+        writer.writeLines(exportWriter.toString());
+        writer.indent--;
+        writer.writeLine(`});`);
+        return writer.toString();
+    }
+    function writeES2015Bundle(node) {
+        visit(node);
+        const writer = new TextWriter();
+        writer.writeLines(copyrightNotice);
+        writer.writeLines(bodyWriter.toString());
+        return writer.toString();
+    }
+    function visit(node) {
+        switch (node.kind) {
+            case ts.SyntaxKind.Bundle: return visitBundle(node);
+            case ts.SyntaxKind.SourceFile: return visitSourceFile(node);
+            case ts.SyntaxKind.VariableStatement: return visitVariableStatement(node);
+            case ts.SyntaxKind.FunctionDeclaration: return visitFunctionDeclaration(node);
+            default:
+                reportError(node, `${ts.SyntaxKind[node.kind]} not supported at the top level.`);
+                return undefined;
+        }
+    }
+    function visitBundle(node) {
+        node.sourceFiles.forEach(visit);
+    }
+    function visitSourceFile(node) {
+        sourceFile = node;
+        node.statements.forEach(visit);
+    }
+    function visitFunctionDeclaration(node) {
+        if (ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export) {
+            if (libKind === 0 /* Umd */ || libKind === 1 /* UmdGlobal */) {
+                exportWriter.writeLine(`exporter("${ts.idText(node.name)}", ${ts.idText(node.name)});`);
+                const parametersText = sourceFile.text.slice(node.parameters.pos, node.parameters.end);
+                const bodyText = node.body.getText();
+                if (libKind === 1 /* UmdGlobal */) {
+                    globalWriter.writeLine(`var ${ts.idText(node.name)};`);
+                    bodyWriter.writeLines(`${ts.idText(node.name)} = function (${parametersText}) ${bodyText};`);
+                }
+                else {
+                    bodyWriter.writeLines(`function ${ts.idText(node.name)}(${parametersText}) ${bodyText}`);
+                }
+                bodyWriter.writeLine();
+                return;
+            }
+        }
+        bodyWriter.writeLines(node.getText());
+        bodyWriter.writeLine();
+    }
+    function visitVariableStatement(node) {
+        if (ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export) {
+            if (node.declarationList.declarations.length > 1) {
+                reportError(node, `Only single variables are supported on exported variable statements.`);
+                return;
+            }
+            const variable = node.declarationList.declarations[0];
+            if (variable.name.kind !== ts.SyntaxKind.Identifier) {
+                reportError(variable.name, `Only identifier names are supported on exported variable statements.`);
+                return;
+            }
+            if (!variable.initializer) {
+                reportError(variable.name, `Exported variables must have an initializer.`);
+                return;
+            }
+            if (libKind === 0 /* Umd */ || libKind === 1 /* UmdGlobal */) {
+                if (libKind === 1 /* UmdGlobal */) {
+                    globalWriter.writeLine(`var ${ts.idText(variable.name)};`);
+                    bodyWriter.writeLines(`${ts.idText(variable.name)} = ${variable.initializer.getText()};`);
+                }
+                else if (ts.isFunctionExpression(variable.initializer)) {
+                    const parametersText = sourceFile.text.slice(variable.initializer.parameters.pos, variable.initializer.parameters.end);
+                    const bodyText = variable.initializer.body.getText();
+                    bodyWriter.writeLines(`function ${ts.idText(variable.name)}(${parametersText}) ${bodyText}`);
+                    bodyWriter.writeLine();
+                }
+                else {
+                    bodyWriter.writeLines(`var ${ts.idText(variable.name)} = ${variable.initializer.getText()};`);
+                }
+                bodyWriter.writeLine();
+                exportWriter.writeLine(`exporter("${ts.idText(variable.name)}", ${ts.idText(variable.name)});`);
+                return;
+            }
+            if (ts.isFunctionExpression(variable.initializer)) {
+                const parametersText = sourceFile.text.slice(variable.initializer.parameters.pos, variable.initializer.parameters.end);
+                const bodyText = variable.initializer.body.getText();
+                bodyWriter.writeLines(`export function ${ts.idText(variable.name)}(${parametersText}) ${bodyText}`);
+                bodyWriter.writeLine();
+                return;
+            }
+        }
+        bodyWriter.writeLines(node.getText());
+        bodyWriter.writeLine();
+    }
+}

--- a/scripts/generator.ts
+++ b/scripts/generator.ts
@@ -1,0 +1,293 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import * as ts from "typescript";
+
+const rootDir = path.resolve(__dirname, `..`);
+const srcDir = path.resolve(rootDir, `src`);
+const copyrightNotice = fs.readFileSync(path.resolve(rootDir, "CopyrightNotice.txt"), "utf8");
+const umdGlobalsExporter = fs.readFileSync(path.resolve(srcDir, "umdGlobals.js"), "utf8");
+const umdExporter = fs.readFileSync(path.resolve(srcDir, "umd.js"), "utf8");
+const tslibFile = path.resolve(srcDir, "tslib.js");
+const indentStrings: string[] = ["", "    "];
+const MAX_SMI_X86 = 0x3fff_ffff;
+
+const enum LibKind {
+    Umd,
+    UmdGlobal,
+    ES2015
+}
+
+class TextWriter {
+    public indent = 0;
+    private output = "";
+    private pendingNewLines = 0;
+
+    write(s: string) {
+        if (s && s.length) {
+            this.writePendingNewLines();
+            this.output += s;
+        }
+    }
+
+    writeLine(s?: string) {
+        this.write(s);
+        this.pendingNewLines++;
+    }
+
+    writeLines(s: string): void {
+        if (s) {
+            const lines = s.split(/\r\n?|\n/g);
+            const indentation = guessIndentation(lines);
+            for (const lineText of lines) {
+                const line = indentation ? lineText.slice(indentation) : lineText;
+                if (!this.pendingNewLines && this.output.length > 0) {
+                    this.writeLine();
+                }
+                this.writeLine(line);
+            }
+        }
+    }
+
+    toString() {
+        return this.output;
+    }
+
+    private writePendingNewLines() {
+        if (this.pendingNewLines > 0) {
+            do {
+                this.output += "\n";
+                this.pendingNewLines--;
+            }
+            while (this.pendingNewLines > 0);
+            this.output += getIndentString(this.indent);
+        }
+    }
+}
+
+main();
+
+function main() {
+    const sourceFiles = parseSources();
+    generateSingleFileVariations(sourceFiles, rootDir);
+}
+
+function getIndentString(level: number) {
+    if (indentStrings[level] === undefined) {
+        indentStrings[level] = getIndentString(level - 1) + indentStrings[1];
+    }
+    return indentStrings[level];
+}
+
+function guessIndentation(lines: string[]) {
+    let indentation = MAX_SMI_X86;
+    for (const line of lines) {
+        if (!line.length) {
+            continue;
+        }
+        let i = 0;
+        for (; i < line.length && i < indentation; i++) {
+            if (!/^[\s\r\n]/.test(line.charAt(i))) {
+                break;
+            }
+        }
+        if (i < indentation) {
+            indentation = i;
+        }
+        if (indentation === 0) {
+            return 0;
+        }
+    }
+    return indentation === MAX_SMI_X86 ? undefined : indentation;
+}
+
+function mkdirpSync(dir: string) {
+    try {
+        fs.mkdirSync(dir);
+    }
+    catch (e) {
+        if (e.code === "EEXIST") return;
+        if (e.code === "ENOENT") {
+            const parent = path.dirname(dir);
+            if (parent && parent !== dir) {
+                mkdirpSync(parent);
+                fs.mkdirSync(dir);
+                return;
+            }
+        }
+        throw e;
+    }
+}
+
+function parse(file: string) {
+    const sourceText = fs.readFileSync(file, "utf8");
+    const sourceFile = ts.createSourceFile(file, sourceText, ts.ScriptTarget.ES3, /*setParentNodes*/ true, ts.ScriptKind.JS);
+    return sourceFile;
+}
+
+function parseSources() {
+    const sourceFiles: ts.SourceFile[] = [];
+    sourceFiles.push(parse(tslibFile));
+    return sourceFiles;
+}
+
+function generateSingleFileVariations(sourceFiles: ts.SourceFile[], outDir: string) {
+    generateSingleFile(sourceFiles, path.resolve(outDir, "tslib.js"), LibKind.UmdGlobal);
+    generateSingleFile(sourceFiles, path.resolve(outDir, "tslib.umd.js"), LibKind.Umd);
+    generateSingleFile(sourceFiles, path.resolve(outDir, "tslib.es6.js"), LibKind.ES2015);
+}
+
+function generateSingleFile(sourceFiles: ts.SourceFile[], outFile: string, libKind: LibKind) {
+    const bundle = ts.createBundle(sourceFiles);
+    const output = write(bundle, libKind);
+    mkdirpSync(path.dirname(outFile));
+    fs.writeFileSync(outFile, output, "utf8");
+}
+
+function formatMessage(node: ts.Node, message: string) {
+    const sourceFile = node.getSourceFile();
+    if (sourceFile) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        return `${sourceFile.fileName}(${line + 1}, ${character + 1}): ${message}`;
+    }
+    return message;
+}
+
+function reportError(node: ts.Node, message: string) {
+    console.error(formatMessage(node, message));
+}
+
+function write(source: ts.Bundle, libKind: LibKind) {
+    const globalWriter = new TextWriter();
+    const bodyWriter = new TextWriter();
+    const exportWriter = new TextWriter();
+    let sourceFile: ts.SourceFile | undefined;
+
+    return writeBundle(source);
+
+    function writeBundle(node: ts.Bundle) {
+        switch (libKind) {
+            case LibKind.Umd:
+            case LibKind.UmdGlobal:
+                return writeUmdBundle(node);
+            case LibKind.ES2015:
+                return writeES2015Bundle(node);
+        }
+    }
+
+    function writeUmdBundle(node: ts.Bundle) {
+        visit(node);
+        const writer = new TextWriter();
+        writer.writeLines(copyrightNotice);
+        writer.writeLines(globalWriter.toString());
+        writer.writeLines(libKind === LibKind.UmdGlobal ? umdGlobalsExporter : umdExporter);
+        writer.writeLine(`(function (exporter) {`);
+        writer.indent++;
+        writer.writeLines(bodyWriter.toString());
+        writer.writeLine();
+        writer.writeLines(exportWriter.toString());
+        writer.indent--;
+        writer.writeLine(`});`);
+        return writer.toString();
+    }
+
+    function writeES2015Bundle(node: ts.Bundle) {
+        visit(node);
+        const writer = new TextWriter();
+        writer.writeLines(copyrightNotice);
+        writer.writeLines(bodyWriter.toString());
+        return writer.toString();
+    }
+
+    function visit(node: ts.Node) {
+        switch (node.kind) {
+            case ts.SyntaxKind.Bundle: return visitBundle(<ts.Bundle>node);
+            case ts.SyntaxKind.SourceFile: return visitSourceFile(<ts.SourceFile>node);
+            case ts.SyntaxKind.VariableStatement: return visitVariableStatement(<ts.VariableStatement>node);
+            case ts.SyntaxKind.FunctionDeclaration: return visitFunctionDeclaration(<ts.FunctionDeclaration>node);
+            default:
+                reportError(node, `${ts.SyntaxKind[node.kind]} not supported at the top level.`);
+                return undefined;
+        }
+    }
+
+    function visitBundle(node: ts.Bundle) {
+        node.sourceFiles.forEach(visit);
+    }
+
+    function visitSourceFile(node: ts.SourceFile) {
+        sourceFile = node;
+        node.statements.forEach(visit);
+    }
+
+    function visitFunctionDeclaration(node: ts.FunctionDeclaration) {
+        if (ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export) {
+            if (libKind === LibKind.Umd || libKind === LibKind.UmdGlobal) {
+                exportWriter.writeLine(`exporter("${ts.idText(node.name)}", ${ts.idText(node.name)});`);
+                const parametersText = sourceFile.text.slice(node.parameters.pos, node.parameters.end);
+                const bodyText = node.body.getText();
+                if (libKind === LibKind.UmdGlobal) {
+                    globalWriter.writeLine(`var ${ts.idText(node.name)};`);
+                    bodyWriter.writeLines(`${ts.idText(node.name)} = function (${parametersText}) ${bodyText};`);
+                }
+                else {
+                    bodyWriter.writeLines(`function ${ts.idText(node.name)}(${parametersText}) ${bodyText}`);
+                }
+                bodyWriter.writeLine();
+                return;
+            }
+        }
+        bodyWriter.writeLines(node.getText());
+        bodyWriter.writeLine();
+    }
+
+    function visitVariableStatement(node: ts.VariableStatement) {
+        if (ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export) {
+            if (node.declarationList.declarations.length > 1) {
+                reportError(node, `Only single variables are supported on exported variable statements.`);
+                return;
+            }
+
+            const variable = node.declarationList.declarations[0];
+            if (variable.name.kind !== ts.SyntaxKind.Identifier) {
+                reportError(variable.name, `Only identifier names are supported on exported variable statements.`);
+                return;
+            }
+
+            if (!variable.initializer) {
+                reportError(variable.name, `Exported variables must have an initializer.`);
+                return;
+            }
+
+            if (libKind === LibKind.Umd || libKind === LibKind.UmdGlobal) {
+                if (libKind === LibKind.UmdGlobal) {
+                    globalWriter.writeLine(`var ${ts.idText(variable.name)};`);
+                    bodyWriter.writeLines(`${ts.idText(variable.name)} = ${variable.initializer.getText()};`);
+                }
+                else if (ts.isFunctionExpression(variable.initializer)) {
+                    const parametersText = sourceFile.text.slice(variable.initializer.parameters.pos, variable.initializer.parameters.end);
+                    const bodyText = variable.initializer.body.getText();
+                    bodyWriter.writeLines(`function ${ts.idText(variable.name)}(${parametersText}) ${bodyText}`);
+                    bodyWriter.writeLine();
+                }
+                else {
+                    bodyWriter.writeLines(`var ${ts.idText(variable.name)} = ${variable.initializer.getText()};`);
+                }
+                bodyWriter.writeLine();
+                exportWriter.writeLine(`exporter("${ts.idText(variable.name)}", ${ts.idText(variable.name)});`);
+                return;
+            }
+
+            if (ts.isFunctionExpression(variable.initializer)) {
+                const parametersText = sourceFile.text.slice(variable.initializer.parameters.pos, variable.initializer.parameters.end);
+                const bodyText = variable.initializer.body.getText();
+                bodyWriter.writeLines(`export function ${ts.idText(variable.name)}(${parametersText}) ${bodyText}`);
+                bodyWriter.writeLine();
+                return;
+            }
+        }
+
+        bodyWriter.writeLines(node.getText());
+        bodyWriter.writeLine();
+    }
+}

--- a/src/tslib.js
+++ b/src/tslib.js
@@ -1,0 +1,162 @@
+var extendStatics = Object.setPrototypeOf ||
+    ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+    function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+
+export function __extends(d, b) {
+    extendStatics(d, b);
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+}
+
+export var __assign = Object.assign || function (t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+    }
+    return t;
+};
+
+export function __rest(s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+}
+
+export function __decorate(decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+}
+
+export function __param(paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+}
+
+export function __metadata(metadataKey, metadataValue) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(metadataKey, metadataValue);
+}
+
+export function __awaiter(thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+}
+
+export function __generator(thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+}
+
+export function __exportStar(m, exports) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+
+export function __values(o) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
+    if (m) return m.call(o);
+    return {
+        next: function () {
+            if (o && i >= o.length) o = void 0;
+            return { value: o && o[i++], done: !o };
+        }
+    };
+}
+
+export function __read(o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+}
+
+export function __spread() {
+    for (var ar = [], i = 0; i < arguments.length; i++)
+        ar = ar.concat(__read(arguments[i]));
+    return ar;
+}
+
+export function __await(v) {
+    return this instanceof __await ? (this.v = v, this) : new __await(v);
+}
+
+export function __asyncGenerator(thisArg, _arguments, generator) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var g = generator.apply(thisArg, _arguments || []), i, q = [];
+    return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+    function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+    function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+    function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r);  }
+    function fulfill(value) { resume("next", value); }
+    function reject(value) { resume("throw", value); }
+    function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+}
+
+export function __asyncDelegator(o) {
+    var i, p;
+    return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
+    function verb(n, f) { if (o[n]) i[n] = function (v) { return (p = !p) ? { value: __await(o[n](v)), done: n === "return" } : f ? f(v) : v; }; }
+}
+
+export function __asyncValues(o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
+}
+
+export function __makeTemplateObject(cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+}
+
+export function __importStar(mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+}
+
+export function __importDefault(mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+}

--- a/src/umd.js
+++ b/src/umd.js
@@ -1,0 +1,17 @@
+(function (factory) {
+    if (typeof define === "function" && define.amd) {
+        define("tslib", ["exports"], function (exports) { factory(createExporter(exports)); });
+    }
+    else if (typeof module === "object" && typeof module.exports === "object") {
+        factory(createExporter(module.exports));
+    }
+    function createExporter(exports) {
+        if (typeof Object.create === "function") {
+            Object.defineProperty(exports, "__esModule", { value: true });
+        }
+        else {
+            exports.__esModule = true;
+        }
+        return function (id, v) { return exports[id] = v; };
+    }
+})

--- a/src/umdGlobals.js
+++ b/src/umdGlobals.js
@@ -1,0 +1,23 @@
+(function (factory) {
+    var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
+    if (typeof define === "function" && define.amd) {
+        define("tslib", ["exports"], function (exports) { factory(createExporter(root, createExporter(exports))); });
+    }
+    else if (typeof module === "object" && typeof module.exports === "object") {
+        factory(createExporter(root, createExporter(module.exports)));
+    }
+    else {
+        factory(createExporter(root));
+    }
+    function createExporter(exports, previous) {
+        if (exports !== root) {
+            if (typeof Object.create === "function") {
+                Object.defineProperty(exports, "__esModule", { value: true });
+            }
+            else {
+                exports.__esModule = true;
+            }
+        }
+        return function (id, v) { return exports[id] = previous ? previous(id, v) : v; };
+    }
+})

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -12,7 +12,6 @@ MERCHANTABLITY OR NON-INFRINGEMENT.
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
-/* global Reflect, Promise */
 
 var extendStatics = Object.setPrototypeOf ||
     ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
@@ -24,13 +23,13 @@ export function __extends(d, b) {
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 }
 
-export var __assign = Object.assign || function __assign(t) {
+export var __assign = Object.assign || function (t) {
     for (var s, i = 1, n = arguments.length; i < n; i++) {
         s = arguments[i];
         for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
     }
     return t;
-}
+};
 
 export function __rest(s, e) {
     var t = {};
@@ -163,16 +162,16 @@ export function __asyncValues(o) {
 export function __makeTemplateObject(cooked, raw) {
     if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
     return cooked;
-};
+}
 
 export function __importStar(mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
     if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result.default = mod;
+    result["default"] = mod;
     return result;
 }
 
 export function __importDefault(mod) {
-    return (mod && mod.__esModule) ? mod : { default: mod };
+    return (mod && mod.__esModule) ? mod : { "default": mod };
 }

--- a/tslib.umd.js
+++ b/tslib.umd.js
@@ -13,46 +13,21 @@ See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
 
-var __extends;
-var __assign;
-var __rest;
-var __decorate;
-var __param;
-var __metadata;
-var __awaiter;
-var __generator;
-var __exportStar;
-var __values;
-var __read;
-var __spread;
-var __await;
-var __asyncGenerator;
-var __asyncDelegator;
-var __asyncValues;
-var __makeTemplateObject;
-var __importStar;
-var __importDefault;
 (function (factory) {
-    var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
     if (typeof define === "function" && define.amd) {
-        define("tslib", ["exports"], function (exports) { factory(createExporter(root, createExporter(exports))); });
+        define("tslib", ["exports"], function (exports) { factory(createExporter(exports)); });
     }
     else if (typeof module === "object" && typeof module.exports === "object") {
-        factory(createExporter(root, createExporter(module.exports)));
+        factory(createExporter(module.exports));
     }
-    else {
-        factory(createExporter(root));
-    }
-    function createExporter(exports, previous) {
-        if (exports !== root) {
-            if (typeof Object.create === "function") {
-                Object.defineProperty(exports, "__esModule", { value: true });
-            }
-            else {
-                exports.__esModule = true;
-            }
+    function createExporter(exports) {
+        if (typeof Object.create === "function") {
+            Object.defineProperty(exports, "__esModule", { value: true });
         }
-        return function (id, v) { return exports[id] = previous ? previous(id, v) : v; };
+        else {
+            exports.__esModule = true;
+        }
+        return function (id, v) { return exports[id] = v; };
     }
 })
 (function (exporter) {
@@ -60,13 +35,13 @@ var __importDefault;
         ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
         function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
 
-    __extends = function (d, b) {
+    function __extends(d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
+    }
 
-    __assign = Object.assign || function (t) {
+    var __assign = Object.assign || function (t) {
         for (var s, i = 1, n = arguments.length; i < n; i++) {
             s = arguments[i];
             for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
@@ -74,7 +49,7 @@ var __importDefault;
         return t;
     };
 
-    __rest = function (s, e) {
+    function __rest(s, e) {
         var t = {};
         for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
             t[p] = s[p];
@@ -82,33 +57,33 @@ var __importDefault;
             for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
                 t[p[i]] = s[p[i]];
         return t;
-    };
+    }
 
-    __decorate = function (decorators, target, key, desc) {
+    function __decorate(decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
         if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
-    };
+    }
 
-    __param = function (paramIndex, decorator) {
+    function __param(paramIndex, decorator) {
         return function (target, key) { decorator(target, key, paramIndex); }
-    };
+    }
 
-    __metadata = function (metadataKey, metadataValue) {
+    function __metadata(metadataKey, metadataValue) {
         if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(metadataKey, metadataValue);
-    };
+    }
 
-    __awaiter = function (thisArg, _arguments, P, generator) {
+    function __awaiter(thisArg, _arguments, P, generator) {
         return new (P || (P = Promise))(function (resolve, reject) {
             function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
             function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
             function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
-    };
+    }
 
-    __generator = function (thisArg, body) {
+    function __generator(thisArg, body) {
         var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
         return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
         function verb(n) { return function (v) { return step([n, v]); }; }
@@ -134,13 +109,13 @@ var __importDefault;
             } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
             if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
         }
-    };
+    }
 
-    __exportStar = function (m, exports) {
+    function __exportStar(m, exports) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-    };
+    }
 
-    __values = function (o) {
+    function __values(o) {
         var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
         if (m) return m.call(o);
         return {
@@ -149,9 +124,9 @@ var __importDefault;
                 return { value: o && o[i++], done: !o };
             }
         };
-    };
+    }
 
-    __read = function (o, n) {
+    function __read(o, n) {
         var m = typeof Symbol === "function" && o[Symbol.iterator];
         if (!m) return o;
         var i = m.call(o), r, ar = [], e;
@@ -166,19 +141,19 @@ var __importDefault;
             finally { if (e) throw e.error; }
         }
         return ar;
-    };
+    }
 
-    __spread = function () {
+    function __spread() {
         for (var ar = [], i = 0; i < arguments.length; i++)
             ar = ar.concat(__read(arguments[i]));
         return ar;
-    };
+    }
 
-    __await = function (v) {
+    function __await(v) {
         return this instanceof __await ? (this.v = v, this) : new __await(v);
-    };
+    }
 
-    __asyncGenerator = function (thisArg, _arguments, generator) {
+    function __asyncGenerator(thisArg, _arguments, generator) {
         if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
         var g = generator.apply(thisArg, _arguments || []), i, q = [];
         return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
@@ -188,36 +163,36 @@ var __importDefault;
         function fulfill(value) { resume("next", value); }
         function reject(value) { resume("throw", value); }
         function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
-    };
+    }
 
-    __asyncDelegator = function (o) {
+    function __asyncDelegator(o) {
         var i, p;
         return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
         function verb(n, f) { if (o[n]) i[n] = function (v) { return (p = !p) ? { value: __await(o[n](v)), done: n === "return" } : f ? f(v) : v; }; }
-    };
+    }
 
-    __asyncValues = function (o) {
+    function __asyncValues(o) {
         if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
         var m = o[Symbol.asyncIterator];
         return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
-    };
+    }
 
-    __makeTemplateObject = function (cooked, raw) {
+    function __makeTemplateObject(cooked, raw) {
         if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
         return cooked;
-    };
+    }
 
-    __importStar = function (mod) {
+    function __importStar(mod) {
         if (mod && mod.__esModule) return mod;
         var result = {};
         if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
         result["default"] = mod;
         return result;
-    };
+    }
 
-    __importDefault = function (mod) {
+    function __importDefault(mod) {
         return (mod && mod.__esModule) ? mod : { "default": mod };
-    };
+    }
 
     exporter("__extends", __extends);
     exporter("__assign", __assign);


### PR DESCRIPTION
This adds a _tslib.umd.js_ file as the package main to reduce the impact of global variable pollution. Also, in an effort to avoid redundancy between _tslib.js_, _tslib.umd.js_, and _tslib.es6.js_, this adds a script to generate the three files from a single source.

Fixes: #32