### PR TITLE
side-effect-free package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "type": "git",
         "url": "https://github.com/Microsoft/tslib.git"
     },
+    "sideEffects": false,
     "main": "tslib.js",
     "module": "tslib.es6.js",
     "jsnext:main": "tslib.es6.js",


### PR DESCRIPTION
Added parameter `sideEffects: false` in packages.json, because webpack used this parameters for effective tree shaking - https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free