### PR TITLE
Work around runtime error when using esModuleInterop

### DIFF
--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -182,5 +182,5 @@ export function __importStar(mod) {
 }
 
 export function __importDefault(mod) {
-    return (mod && mod.__esModule) ? mod : { default: mod };
+    return (mod && mod.__esModule && Object.hasOwnProperty.call(mod, "default")) ? mod : { default: mod };
 }

--- a/tslib.js
+++ b/tslib.js
@@ -218,7 +218,7 @@ var __importDefault;
     };
 
     __importDefault = function (mod) {
-        return (mod && mod.__esModule) ? mod : { "default": mod };
+        return (mod && mod.__esModule && Object.hasOwnProperty.call(mod, "default")) ? mod : { "default": mod };
     };
 
     exporter("__extends", __extends);


### PR DESCRIPTION
This is done by changing the `__importDefault` helper to import a module as-is only if the module has "default" defined.

This is a workaround for the error described in https://github.com/Microsoft/TypeScript/issues/27329. See https://github.com/Shingyx/esmoduleinterop-runtime-error for a sample project which demonstrates the runtime error.