### PR TITLE
Readme: language specification link 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ There are many ways to [contribute](https://github.com/Microsoft/TypeScript/blob
 * Engage with other TypeScript users and developers on [StackOverflow](http://stackoverflow.com/questions/tagged/typescript).
 * Join the [#typescript](http://twitter.com/#!/search/realtime/%23typescript) discussion on Twitter.
 * [Contribute bug fixes](https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md).
-* Read the language specification ([docx](http://go.microsoft.com/fwlink/?LinkId=267121), [pdf](http://go.microsoft.com/fwlink/?LinkId=267238)).
+* [Read the language specification](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md)
 
 # Documentation
 


### PR DESCRIPTION
http://www.typescriptlang.org/Content/TypeScript%20Language%20Specification.docx (_and the pdf_) are 404
<img width="777" alt="Screen Shot 2019-04-20 at 1 13 51 AM" src="https://user-images.githubusercontent.com/4022631/56454685-ab38e980-6309-11e9-825b-aea9358b6b3f.png">


so the link is now pointed to https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md