### PR TITLE
Indicate package.json 'module' entry has no side effects for WebPack

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "main": "tslib.js",
     "module": "tslib.es6.js",
     "jsnext:main": "tslib.es6.js",
-    "typings": "tslib.d.ts"
+    "typings": "tslib.d.ts",
+    "sideEffects": false
 }


### PR DESCRIPTION
For WebPack, marks our package as not having side effects. This should only effect WebPack, which uses the package.json's `"module"` entry (`"tslib.es6.js"`), rather than the `"main"` entry.