### PR TITLE
add helpers for private-named instance fields

### DIFF
--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -32,3 +32,5 @@ export declare function __asyncValues(o: any): any;
 export declare function __makeTemplateObject(cooked: string[], raw: string[]): TemplateStringsArray;
 export declare function __importStar<T>(mod: T): T;
 export declare function __importDefault<T>(mod: T): T | { default: T };
+export declare function __classPrivateFieldGet(receiver: any, privateMap: WeakMap<any, any>): any;
+export declare function __classPrivateFieldSet(receiver: any, privateMap: WeakMap<any, any>, value: any): any;

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -196,3 +196,18 @@ export function __importStar(mod) {
 export function __importDefault(mod) {
     return (mod && mod.__esModule) ? mod : { default: mod };
 }
+
+export function __classPrivateFieldGet(receiver, privateMap) {
+    if (!privateMap.has(receiver)) {
+        throw new TypeError("attempted to get private field on non-instance");
+    }
+    return privateMap.get(receiver);
+}
+
+export function __classPrivateFieldSet(receiver, privateMap, value) {
+    if (!privateMap.has(receiver)) {
+        throw new TypeError("attempted to set private field on non-instance");
+    }
+    privateMap.set(receiver, value);
+    return value;
+}

--- a/tslib.js
+++ b/tslib.js
@@ -33,6 +33,8 @@ var __asyncValues;
 var __makeTemplateObject;
 var __importStar;
 var __importDefault;
+var __classPrivateFieldGet;
+var __classPrivateFieldSet;
 (function (factory) {
     var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
     if (typeof define === "function" && define.amd) {
@@ -234,6 +236,21 @@ var __importDefault;
         return (mod && mod.__esModule) ? mod : { "default": mod };
     };
 
+    __classPrivateFieldGet = function (receiver, privateMap) {
+        if (!privateMap.has(receiver)) {
+            throw new TypeError("attempted to get private field on non-instance");
+        }
+        return privateMap.get(receiver);
+    };
+
+    __classPrivateFieldSet = function (receiver, privateMap, value) {
+        if (!privateMap.has(receiver)) {
+            throw new TypeError("attempted to set private field on non-instance");
+        }
+        privateMap.set(receiver, value);
+        return value;
+    }
+
     exporter("__extends", __extends);
     exporter("__assign", __assign);
     exporter("__rest", __rest);
@@ -254,4 +271,6 @@ var __importDefault;
     exporter("__makeTemplateObject", __makeTemplateObject);
     exporter("__importStar", __importStar);
     exporter("__importDefault", __importDefault);
+    exporter("__classPrivateFieldGet", __classPrivateFieldGet);
+    exporter("__classPrivateFieldSet", __classPrivateFieldSet);
 });


### PR DESCRIPTION
A companion to https://github.com/microsoft/TypeScript/pull/30829, this PR adds the helper methods for private-named instance fields into tslib.

The original helper methods were written by @joeywatts and @mheiber in the aforementioned PR. They have simply been copied and exposed here.