### PR TITLE
use getters for exportStar helper

### DIFF
--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -104,7 +104,15 @@ export function __generator(thisArg, body) {
 }
 
 export function __exportStar(m, exports) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+    for (var p in m) b(p);
+    function b(p) {
+        if (!exports.hasOwnProperty(p)) Object.defineProperty(exports, p, {
+            enumerable: true,
+            get: function () {
+                return m[p];
+            }
+        });
+    }
 }
 
 export function __values(o) {

--- a/tslib.js
+++ b/tslib.js
@@ -141,7 +141,15 @@ var __importDefault;
     };
 
     __exportStar = function (m, exports) {
-        for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+        for (var p in m) b(p);
+        function b(p) {
+            if (!exports.hasOwnProperty(p)) Object.defineProperty(exports, p, {
+                enumerable: true,
+                get: function () {
+                    return m[p];
+                }
+            });
+        }
     };
 
     __values = function (o) {


### PR DESCRIPTION
This PR makes the same change to the tslib helper as was made in https://github.com/microsoft/TypeScript/pull/33587 to the inline helper which makes re-exported bindings live rather than snapshots.