### PR TITLE
build: exclude github workflows from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .gitattributes
+.github
 bower.json
 docs


### PR DESCRIPTION
In the latest release tslib contains the `.github` folder as part of the distributable. 

https://unpkg.com/browse/tslib@1.11.0/