### PR TITLE
Remove reference to WeakMap from tslib.d.ts

### DIFF
--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -32,5 +32,5 @@ export declare function __asyncValues(o: any): any;
 export declare function __makeTemplateObject(cooked: string[], raw: string[]): TemplateStringsArray;
 export declare function __importStar<T>(mod: T): T;
 export declare function __importDefault<T>(mod: T): T | { default: T };
-export declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: WeakMap<T, V>): V;
-export declare function __classPrivateFieldSet<T extends object, V>(receiver: T, privateMap: WeakMap<T, V>, value: V): V;
+export declare function __classPrivateFieldGet(receiver: object, privateMap: object): any;
+export declare function __classPrivateFieldSet(receiver: object, privateMap: object, value: any): any;

--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -32,5 +32,5 @@ export declare function __asyncValues(o: any): any;
 export declare function __makeTemplateObject(cooked: string[], raw: string[]): TemplateStringsArray;
 export declare function __importStar<T>(mod: T): T;
 export declare function __importDefault<T>(mod: T): T | { default: T };
-export declare function __classPrivateFieldGet(receiver: object, privateMap: object): any;
-export declare function __classPrivateFieldSet(receiver: object, privateMap: object, value: any): any;
+export declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, get(o: T): V }): V;
+export declare function __classPrivateFieldSet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, set(o: T, value: V): any }, value: V): V;

--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -32,5 +32,5 @@ export declare function __asyncValues(o: any): any;
 export declare function __makeTemplateObject(cooked: string[], raw: string[]): TemplateStringsArray;
 export declare function __importStar<T>(mod: T): T;
 export declare function __importDefault<T>(mod: T): T | { default: T };
-export declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, get(o: T): V }): V;
+export declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, get(o: T): V | undefined }): V;
 export declare function __classPrivateFieldSet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, set(o: T, value: V): any }, value: V): V;


### PR DESCRIPTION
Unfortunately, `WeakMap` may not be declared when using tslib with a project that has `"lib": ["es5"]` set.

Fixes: #93