### PR TITLE
fix: add missing semi colons after method names

### DIFF
--- a/tslib.js
+++ b/tslib.js
@@ -145,7 +145,7 @@ var __createBinding;
 
     __exportStar = function(m, exports) {
         for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-    }
+    };
 
     __createBinding = Object.create ? (function(o, m, k, k2) {
         if (k2 === undefined) k2 = k;
@@ -264,7 +264,7 @@ var __createBinding;
         }
         privateMap.set(receiver, value);
         return value;
-    }
+    };
 
     exporter("__extends", __extends);
     exporter("__assign", __assign);


### PR DESCRIPTION
See: https://github.com/microsoft/TypeScript/issues/38501