### PR TITLE
Revert changes to pre-3.9 behavior, update version to 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For JSPM users:
         "importHelpers": true,
         "baseUrl": "./",
         "paths": {
-            "tslib" : ["jspm_packages/npm/tslib@1.12.0/tslib.d.ts"]
+            "tslib" : ["jspm_packages/npm/tslib@1.13.0/tslib.d.ts"]
         }
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "Microsoft Corp."
   ],
   "homepage": "http://typescriptlang.org/",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "0BSD",
   "description": "Runtime library for TypeScript helper functions",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tslib",
     "author": "Microsoft Corp.",
     "homepage": "https://www.typescriptlang.org/",
-    "version": "1.12.0",
+    "version": "1.13.0",
     "license": "0BSD",
     "description": "Runtime library for TypeScript helper functions",
     "keywords": [

--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -34,3 +34,4 @@ export declare function __importStar<T>(mod: T): T;
 export declare function __importDefault<T>(mod: T): T | { default: T };
 export declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, get(o: T): V | undefined }): V;
 export declare function __classPrivateFieldSet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, set(o: T, value: V): any }, value: V): V;
+export declare function __createBinding(object: object, target: object, key: PropertyKey, objectKey?: PropertyKey): void;

--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -34,4 +34,3 @@ export declare function __importStar<T>(mod: T): T;
 export declare function __importDefault<T>(mod: T): T | { default: T };
 export declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, get(o: T): V | undefined }): V;
 export declare function __classPrivateFieldSet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, set(o: T, value: V): any }, value: V): V;
-export declare function __createBinding(object: object, target: object, key: PropertyKey, objectKey?: PropertyKey): void;

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -103,16 +103,8 @@ export function __generator(thisArg, body) {
     }
 }
 
-export const __createBinding = Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-});
-
 export function __exportStar(m, exports) {
-    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 
 export function __values(o) {
@@ -193,17 +185,11 @@ export function __makeTemplateObject(cooked, raw) {
     return cooked;
 };
 
-const __setModuleDefault = Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-};
-
 export function __importStar(mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result.default = mod;
     return result;
 }
 

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -109,7 +109,7 @@ export function __createBinding(o, m, k, k2) {
 }
 
 export function __exportStar(m, exports) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 
 export function __values(o) {

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -103,6 +103,11 @@ export function __generator(thisArg, body) {
     }
 }
 
+export function __createBinding(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}
+
 export function __exportStar(m, exports) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }

--- a/tslib.js
+++ b/tslib.js
@@ -35,7 +35,6 @@ var __importStar;
 var __importDefault;
 var __classPrivateFieldGet;
 var __classPrivateFieldSet;
-var __createBinding;
 (function (factory) {
     var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
     if (typeof define === "function" && define.amd) {
@@ -143,17 +142,9 @@ var __createBinding;
         }
     };
 
-    __exportStar = function(m, exports) {
-        for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+    __exportStar = function (m, exports) {
+        for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
     };
-
-    __createBinding = Object.create ? (function(o, m, k, k2) {
-        if (k2 === undefined) k2 = k;
-        Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-    }) : (function(o, m, k, k2) {
-        if (k2 === undefined) k2 = k;
-        o[k2] = m[k];
-    });
 
     __values = function (o) {
         var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
@@ -233,17 +224,11 @@ var __createBinding;
         return cooked;
     };
 
-    var __setModuleDefault = Object.create ? (function(o, v) {
-        Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
-        o["default"] = v;
-    };
-
     __importStar = function (mod) {
         if (mod && mod.__esModule) return mod;
         var result = {};
-        if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-        __setModuleDefault(result, mod);
+        if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+        result["default"] = mod;
         return result;
     };
 
@@ -264,7 +249,7 @@ var __createBinding;
         }
         privateMap.set(receiver, value);
         return value;
-    };
+    }
 
     exporter("__extends", __extends);
     exporter("__assign", __assign);
@@ -275,7 +260,6 @@ var __createBinding;
     exporter("__awaiter", __awaiter);
     exporter("__generator", __generator);
     exporter("__exportStar", __exportStar);
-    exporter("__createBinding", __createBinding);
     exporter("__values", __values);
     exporter("__read", __read);
     exporter("__spread", __spread);

--- a/tslib.js
+++ b/tslib.js
@@ -150,7 +150,7 @@ var __createBinding;
     };
 
     __exportStar = function (m, exports) {
-        for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+        for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) exports[p] = m[p];
     };
 
     __values = function (o) {

--- a/tslib.js
+++ b/tslib.js
@@ -12,6 +12,7 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 ***************************************************************************** */
+
 /* global global, define, System, Reflect, Promise */
 var __extends;
 var __assign;
@@ -35,6 +36,7 @@ var __importStar;
 var __importDefault;
 var __classPrivateFieldGet;
 var __classPrivateFieldSet;
+var __createBinding;
 (function (factory) {
     var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
     if (typeof define === "function" && define.amd) {
@@ -140,6 +142,11 @@ var __classPrivateFieldSet;
             } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
             if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
         }
+    };
+
+    __createBinding = function(o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
     };
 
     __exportStar = function (m, exports) {
@@ -260,6 +267,7 @@ var __classPrivateFieldSet;
     exporter("__awaiter", __awaiter);
     exporter("__generator", __generator);
     exporter("__exportStar", __exportStar);
+    exporter("__createBinding", __createBinding);
     exporter("__values", __values);
     exporter("__read", __read);
     exporter("__spread", __spread);

--- a/tslib.js
+++ b/tslib.js
@@ -256,7 +256,7 @@ var __createBinding;
         }
         privateMap.set(receiver, value);
         return value;
-    }
+    };
 
     exporter("__extends", __extends);
     exporter("__assign", __assign);


### PR DESCRIPTION
Fixes #105
Fixes #106

Here's the plan with this PR:

* Republish 1.11.2 as 1.13.0: this unbreaks people who haven't upgraded to TypeScript 3.9
* Publish 1.12.0 as 2.0.0: this means TypeScript 3.9 won't work on anything older than tslib 2.0