### PR TITLE
feat: support Node.js ES modules via conditional exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+tslib.mjs
+

--- a/package.json
+++ b/package.json
@@ -21,9 +21,19 @@
         "type": "git",
         "url": "https://github.com/Microsoft/tslib.git"
     },
+    "scripts": {
+        "prepare": "cp tslib.es6.js tslib.mjs"
+    },
     "main": "tslib.js",
     "module": "tslib.es6.js",
     "jsnext:main": "tslib.es6.js",
+    "exports": {
+        ".": {
+            "require": "./tslib.js",
+            "import": "./tslib.mjs"
+        }
+    },
     "typings": "tslib.d.ts",
     "sideEffects": false
 }
+


### PR DESCRIPTION
Copies tslib.mjs file from tslib.es6.js as part of `prepare` script.

This change should only affect Node when used with ES modules since the .mjs files is referenced only in conditional export and should be safer.

Resolves #81; closes #84

#87 renames the CJS version to .cjs extension which could potentially break existing bundling/serving tools.

Creating a symbolic link doesn't work since npm package doesn't support it.