### PR TITLE
Add `module` condition, so webpack loads es6 module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sideEffects": false,
     "exports": {
         ".": {
+            "webpack": "./tslib.es6.js",
             "import": "./modules/index.js",
             "default": "./tslib.js"
         },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sideEffects": false,
     "exports": {
         ".": {
-            "webpack": "./tslib.es6.js",
+            "module": "./tslib.es6.js",
             "import": "./modules/index.js",
             "default": "./tslib.js"
         },


### PR DESCRIPTION
Even when handling the `exports` table, as done in `webpack` 5. `webpack` 5, at least at present per [this thread](https://github.com/webpack/webpack/issues/11613), doesn't handle esm/cjs interop the same way as `node`, so we can't use the same source as in `node`. 

This should hopefully cause `webpack` to uniformly prioritize the es module sources, as it did because of the `module` entrypoint before we added `exports`.

@orta you mentioned having a webpack 5 test - care to add it to this PR?