### PR TITLE
Update package.json: changed pattern "./" to "./*"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
             "import": "./modules/index.js",
             "default": "./tslib.js"
         },
-        "./*": "./*"
+        "./*": "./*",
+        "./": "./"
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
             "import": "./modules/index.js",
             "default": "./tslib.js"
         },
-        "./": "./"
+        "./*": "./*"
     }
 }


### PR DESCRIPTION
On Angular when executes command 'ng build --prod': 
- Generating browser application bundles...(node:16716) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at {{APP_PATH}}\node_modules\tslib\package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)