### PR TITLE
#134 getting rid of deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
             "import": "./modules/index.js",
             "default": "./tslib.js"
         },
-        "./": "./"
+        "./*": "./*"
     }
 }


### PR DESCRIPTION
Applying a similar fix to https://github.com/postcss/postcss/issues/1455
based on their merged pull request: https://github.com/postcss/postcss/pull/1456/commits/93359b729275672a56c11aa41c20129e9158b36a

Tested with node `v15.2.1`