### PR TITLE
fix(__decorate): Stop using non‑standard `Reflect.decorate`

### DIFF
--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -54,8 +54,7 @@ export function __rest(s, e) {
 
 export function __decorate(decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 }
 

--- a/tslib.js
+++ b/tslib.js
@@ -95,8 +95,7 @@ var __createBinding;
 
     __decorate = function (decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
 


### PR DESCRIPTION
**TypeScript** PR: <https://github.com/microsoft/TypeScript/pull/36408>

> `Reflect.decorate` is not on a standards track and has no active proposal being championed in TC39.
> We have no idea if `Reflect.decorate` will get added to the language, even if it does, we have no guarantee it will be the implementation we are assuming it to be.
> 
> By having this condition in the code, we are likely preventing `Reflect.decorate` from ever existing in the language, just like `Array.prototype.flatten` had to get a different name because MooTools would attempt to use it if it existed and it was not the implementation MooTools assumed it would be.
> 
> Here is a W3C TAG finding which recommends against usage of speculative features -- <https://www.w3.org/2001/tag/doc/polyfills/#don-t-use-speculative-polyfills-that-defer-to-native-implementations>