### PR TITLE
update private class element helpers

### DIFF
--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -35,6 +35,96 @@ export declare function __asyncValues(o: any): any;
 export declare function __makeTemplateObject(cooked: string[], raw: string[]): TemplateStringsArray;
 export declare function __importStar<T>(mod: T): T;
 export declare function __importDefault<T>(mod: T): T | { default: T };
-export declare function __classPrivateFieldGet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, get(o: T): V | undefined }): V;
-export declare function __classPrivateFieldSet<T extends object, V>(receiver: T, privateMap: { has(o: T): boolean, set(o: T, value: V): any }, value: V): V;
+/**
+ * Reading from a private instance field
+ */
+export declare function __classPrivateFieldGet<T extends object, V>(
+    receiver: T,
+    state: { has(o: T): boolean, get(o: T): V | undefined },
+    kind?: "f"
+): V;
+/**
+ * Reading from a private static field
+ */
+export declare function __classPrivateFieldGet<T extends new (...args: any[]) => unknown, V>(
+    receiver: T,
+    state: T,
+    kind: "f",
+    f: { value: V }
+): V;
+/**
+ * Reading from a private instance get accessor
+ */
+export declare function __classPrivateFieldGet<T extends object, V>(
+    receiver: T,
+    state: { has(o: T): boolean },
+    kind: "a",
+    f: () => V
+): V;
+/**
+ * Reading from a private static get accessor
+ */
+export declare function __classPrivateFieldGet<T extends new (...args: any[]) => unknown, V>(
+    receiver: T,
+    state: T,
+    kind: "a",
+    f: () => V
+): V;
+/**
+ * Reading from a private instance method
+ */
+export declare function __classPrivateFieldGet<T extends object, V extends (...args: any[]) => unknown>(
+    receiver: T,
+    state: { has(o: T): boolean },
+    kind: "m",
+    f: V
+): V;
+/**
+ * Reading from a private static method
+ */
+export declare function __classPrivateFieldGet<T extends new (...args: any[]) => unknown, V extends (...args: any[]) => unknown>(
+    receiver: T,
+    state: T,
+    kind: "m",
+    f: V
+): V;
+/**
+ * Writing to a private instance field
+ */
+ export declare function __classPrivateFieldSet<T extends object, V>(
+    receiver: T,
+    state: { has(o: T): boolean, set(o: T, value: V): unknown },
+    value: V,
+    kind?: "f"
+): V;
+/**
+ * Writing to a private static field
+ */
+export declare function __classPrivateFieldSet<T extends new (...args: any[]) => unknown, V>(
+    receiver: T,
+    state: T,
+    value: V,
+    kind: "f",
+    f: { value: V }
+): V;
+/**
+ * Writing to a private instance set accessor
+ */
+export declare function __classPrivateFieldSet<T extends object, V>(
+    receiver: T,
+    state: { has(o: T): boolean },
+    value: V,
+    kind: "a",
+    f: (v: V) => void
+): V;
+/**
+ * Writing to a private static set accessor
+ */
+export declare function __classPrivateFieldSet<T extends new (...args: any[]) => unknown, V>(
+    receiver: T,
+    state: T,
+    value: V,
+    kind: "a",
+    f: (v: V) => void
+): V;
 export declare function __createBinding(object: object, target: object, key: PropertyKey, objectKey?: PropertyKey): void;

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -221,17 +221,15 @@ export function __importDefault(mod) {
     return (mod && mod.__esModule) ? mod : { default: mod };
 }
 
-export function __classPrivateFieldGet(receiver, privateMap) {
-    if (!privateMap.has(receiver)) {
-        throw new TypeError("attempted to get private field on non-instance");
-    }
-    return privateMap.get(receiver);
+export function __classPrivateFieldGet(receiver, state, kind, f) {
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 }
 
-export function __classPrivateFieldSet(receiver, privateMap, value) {
-    if (!privateMap.has(receiver)) {
-        throw new TypeError("attempted to set private field on non-instance");
-    }
-    privateMap.set(receiver, value);
-    return value;
+export function __classPrivateFieldSet(receiver, state, value, kind, f) {
+    if (kind === "m") throw new TypeError("Private method is not writable");
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
 }

--- a/tslib.js
+++ b/tslib.js
@@ -262,19 +262,17 @@ var __createBinding;
         return (mod && mod.__esModule) ? mod : { "default": mod };
     };
 
-    __classPrivateFieldGet = function (receiver, privateMap) {
-        if (!privateMap.has(receiver)) {
-            throw new TypeError("attempted to get private field on non-instance");
-        }
-        return privateMap.get(receiver);
+    __classPrivateFieldGet = function (receiver, state, kind, f) {
+        if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+        if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+        return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
     };
 
-    __classPrivateFieldSet = function (receiver, privateMap, value) {
-        if (!privateMap.has(receiver)) {
-            throw new TypeError("attempted to set private field on non-instance");
-        }
-        privateMap.set(receiver, value);
-        return value;
+    __classPrivateFieldSet = function (receiver, state, value, kind, f) {
+        if (kind === "m") throw new TypeError("Private method is not writable");
+        if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+        if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+        return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
     };
 
     exporter("__extends", __extends);


### PR DESCRIPTION
A companion to https://github.com/microsoft/TypeScript/pull/42458 - this PR updates `__classPrivateFieldGet` and `__classPrivateFieldSet` helpers to support private instance methods and accessors, and private static elements.

cc: @rbuckton 