### PR TITLE
Fix __spreadArray for non-concat-spreadables

### DIFF
--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -169,7 +169,7 @@ export function __spreadArray(to, from, pack) {
             ar[i] = from[i];
         }
     }
-    return to.concat(ar || from);
+    return to.concat(ar || Array.prototype.slice.call(from));
 }
 
 export function __await(v) {

--- a/tslib.js
+++ b/tslib.js
@@ -210,7 +210,7 @@ var __createBinding;
                 ar[i] = from[i];
             }
         }
-        return to.concat(ar || from);
+        return to.concat(ar || Array.prototype.slice.call(from));
     };
 
     __await = function (v) {


### PR DESCRIPTION
The `__spreadArray` helper uses `Array.concat`, which doesn't work with DOM NodeList or HTMLCollection. This changes the `__spreadArray` helper to fall back to `Array.prototype.slice.call(from)` to ensure the elements of `from` are concatenated properly.

Fixes #153