### PR TITLE
Add new private class element helper: __classPrivateFieldIn

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -24,6 +24,7 @@ const {
     __importDefault,
     __classPrivateFieldGet,
     __classPrivateFieldSet,
+    __classPrivateFieldIn,
 } = tslib;
 export {
     __extends,
@@ -50,4 +51,5 @@ export {
     __importDefault,
     __classPrivateFieldGet,
     __classPrivateFieldSet,
+    __classPrivateFieldIn,
 };

--- a/tslib.d.ts
+++ b/tslib.d.ts
@@ -127,4 +127,11 @@ export declare function __classPrivateFieldSet<T extends new (...args: any[]) =>
     kind: "a",
     f: (v: V) => void
 ): V;
+/**
+ * Checking the existence of a private field/method/accessor
+ */
+export declare function __classPrivateFieldIn(
+    state: (new (...args: any[]) => unknown) | { has(o: any): boolean },
+    receiver: unknown,
+): boolean;
 export declare function __createBinding(object: object, target: object, key: PropertyKey, objectKey?: PropertyKey): void;

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -237,3 +237,8 @@ export function __classPrivateFieldSet(receiver, state, value, kind, f) {
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
     return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
 }
+
+export function __classPrivateFieldIn(state, receiver) {
+    if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+    return typeof state === "function" ? receiver === state : state.has(receiver);
+}

--- a/tslib.js
+++ b/tslib.js
@@ -36,6 +36,7 @@ var __importStar;
 var __importDefault;
 var __classPrivateFieldGet;
 var __classPrivateFieldSet;
+var __classPrivateFieldIn;
 var __createBinding;
 (function (factory) {
     var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
@@ -279,6 +280,11 @@ var __createBinding;
         return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
     };
 
+    __classPrivateFieldIn = function (state, receiver) {
+        if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+        return typeof state === "function" ? receiver === state : state.has(receiver);
+    };
+
     exporter("__extends", __extends);
     exporter("__assign", __assign);
     exporter("__rest", __rest);
@@ -303,4 +309,5 @@ var __createBinding;
     exporter("__importDefault", __importDefault);
     exporter("__classPrivateFieldGet", __classPrivateFieldGet);
     exporter("__classPrivateFieldSet", __classPrivateFieldSet);
+    exporter("__classPrivateFieldIn", __classPrivateFieldIn);
 });


### PR DESCRIPTION
A companion to https://github.com/microsoft/TypeScript/pull/44648 - this PR adds the `__classPrivateFieldIn` helper used when transforming `#field in expression`.

cc: @rbuckton @sandersn 
