### PR TITLE
Don't require license to be included by bundlers

### DIFF
--- a/CopyrightNotice.txt
+++ b/CopyrightNotice.txt
@@ -1,4 +1,4 @@
-/*! *****************************************************************************
+/******************************************************************************
 Copyright (c) Microsoft Corporation.
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
#96 updated the license to zero clause BSD so that bundlers didn't need to keep the license intact.

However, the `/*!` still signifies to bundlers such as Webpack, Uglify that they should keep this license intact.

https://stackoverflow.com/questions/11248363/the-purpose-of-starting-an-initial-comment-with-in-javascript-and-css-files

> This is for legal reasons. By default comments with `@license`, `@preserve` or starting with `/*!` are preserved

https://github.com/webpack/webpack/issues/324#issuecomment-157855568