### PR TITLE
fix: allow spreading of strings within arrays

### DIFF
--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -167,10 +167,15 @@ export function __spreadArrays() {
 }
 
 export function __spreadArray(to, from, pack) {
-    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
-        if (ar || !(i in from)) {
-            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
-            ar[i] = from[i];
+    if (pack || arguments.length === 2) {
+        if (typeof from === "string") from = Array.prototype.slice.call(from);
+        for (var i = 0, l = from.length, ar; i < l; i++) {
+            if (ar || !(i in from)) {
+                if (!ar) {
+                    ar = Array.prototype.slice.call(from, 0, i);
+                }
+                ar[i] = from[i];
+            }
         }
     }
     return to.concat(ar || Array.prototype.slice.call(from));

--- a/tslib.js
+++ b/tslib.js
@@ -209,10 +209,15 @@ var __createBinding;
     };
 
     __spreadArray = function (to, from, pack) {
-        if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
-            if (ar || !(i in from)) {
-                if (!ar) ar = Array.prototype.slice.call(from, 0, i);
-                ar[i] = from[i];
+        if (pack || arguments.length === 2) {
+            if (typeof from === "string") from = Array.prototype.slice.call(from);
+            for (var i = 0, l = from.length, ar; i < l; i++) {
+                if (ar || !(i in from)) {
+                    if (!ar) {
+                        ar = Array.prototype.slice.call(from, 0, i);
+                    }
+                    ar[i] = from[i];
+                }
             }
         }
         return to.concat(ar || Array.prototype.slice.call(from));


### PR DESCRIPTION
Fixes #175 

This restores array spreading for the following use case:

```js
[..."foo"]; // ['f', 'o', 'o']
```

@rbuckton @DanielRosenwasser First time contributing to this project, so please let me know if there's something I missed.