### PR TITLE
fix: default interop compat for "module" condition

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -53,3 +53,4 @@ export {
     __classPrivateFieldSet,
     __classPrivateFieldIn,
 };
+export default tslib;

--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -246,3 +246,31 @@ export function __classPrivateFieldIn(state, receiver) {
     if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
     return typeof state === "function" ? receiver === state : state.has(receiver);
 }
+
+export default {
+    __extends,
+    __assign,
+    __rest,
+    __decorate,
+    __param,
+    __metadata,
+    __awaiter,
+    __generator,
+    __createBinding,
+    __exportStar,
+    __values,
+    __read,
+    __spread,
+    __spreadArrays,
+    __spreadArray,
+    __await,
+    __asyncGenerator,
+    __asyncDelegator,
+    __asyncValues,
+    __makeTemplateObject,
+    __importStar,
+    __importDefault,
+    __classPrivateFieldGet,
+    __classPrivateFieldSet,
+    __classPrivateFieldIn,
+};


### PR DESCRIPTION
This adds default import interop compat when resolving using the `"module"` condition.

Many users are still expecting `import tslib from 'tslib'` to work, since this is supported for the CommonJS interface in both Node.js and browsers, but if building with the `"module"` condition outside of Webpack (eg as import map generators like JSPM do), this results in breaking the tslib interop.

It is always recommended for all exports conditions to provide the same interface. This decoration effectively provides the identical interfaces between the ESM and CJS forms of tslib, maximizing interop.

//cc @weswigham 