### PR TITLE
changes to make vite 4 work

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -1,4 +1,4 @@
-import tslib from '../tslib.js';
+import * as tslib from '../tslib.js';
 const {
     __extends,
     __assign,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "type": "git",
         "url": "https://github.com/Microsoft/tslib.git"
     },
+    "type":"module",
     "main": "tslib.js",
     "module": "tslib.es6.js",
     "jsnext:main": "tslib.es6.js",


### PR DESCRIPTION
I'm trying to use tslib with vite 4.0.1. Dev mode seems to demand 'type':'module' in package.json. It then goes into modules subfolder and complains that '../tslib.js' has no default  export. Can't argue with that, so I added the '* as' to the import. 