### PR TITLE
Add Node-specific export condition for ESM entrypoint that re-exports CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "exports": {
         ".": {
             "module": "./tslib.es6.js",
-            "import": "./modules/index.js",
+            "import": {
+              "node": "./modules/index.js",
+              "default": "./tslib.es6.js"
+            },
             "default": "./tslib.js"
         },
         "./*": "./*",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,16 @@
     "sideEffects": false,
     "exports": {
         ".": {
-            "module": "./tslib.es6.js",
+            "module": {
+              "types": "./tslib.d.ts",
+              "default": "./tslib.es6.js"
+            },
             "import": {
               "node": "./modules/index.js",
-              "default": "./tslib.es6.js"
+              "default": {
+                "types": "./tslib.d.ts",
+                "default": "./tslib.es6.js"
+              }
             },
             "default": "./tslib.js"
         },


### PR DESCRIPTION
Another stab at #171 / #143. Ensures non-Node module resolvers that use `import` do not see CommonJS, while still ensuring Node only ever sees one copy of the helpers.