### PR TITLE
Add 'configurable: true' to descriptors in __createBinding and __setModuleDefault

### DIFF
--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -154,7 +154,7 @@ export var __createBinding = Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
     if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-        desc = { enumerable: true, get: function() { return m[k]; } };
+        desc = { enumerable: true, configurable: true, get: function() { return m[k]; } };
     }
     Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
@@ -258,7 +258,7 @@ export function __makeTemplateObject(cooked, raw) {
 };
 
 var __setModuleDefault = Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
+    Object.defineProperty(o, "default", { enumerable: true, configurable: true, value: v });
 }) : function(o, v) {
     o["default"] = v;
 };

--- a/tslib.es6.mjs
+++ b/tslib.es6.mjs
@@ -154,7 +154,7 @@ export var __createBinding = Object.create ? (function(o, m, k, k2) {
   if (k2 === undefined) k2 = k;
   var desc = Object.getOwnPropertyDescriptor(m, k);
   if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
+      desc = { enumerable: true, configurable: true, get: function() { return m[k]; } };
   }
   Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
@@ -258,7 +258,7 @@ export function __makeTemplateObject(cooked, raw) {
 };
 
 var __setModuleDefault = Object.create ? (function(o, v) {
-  Object.defineProperty(o, "default", { enumerable: true, value: v });
+  Object.defineProperty(o, "default", { enumerable: true, configurable: true, value: v });
 }) : function(o, v) {
   o["default"] = v;
 };

--- a/tslib.js
+++ b/tslib.js
@@ -206,7 +206,7 @@ var __disposeResources;
         if (k2 === undefined) k2 = k;
         var desc = Object.getOwnPropertyDescriptor(m, k);
         if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-            desc = { enumerable: true, get: function() { return m[k]; } };
+            desc = { enumerable: true, configurable: true, get: function() { return m[k]; } };
         }
         Object.defineProperty(o, k2, desc);
     }) : (function(o, m, k, k2) {
@@ -306,7 +306,7 @@ var __disposeResources;
     };
 
     var __setModuleDefault = Object.create ? (function(o, v) {
-        Object.defineProperty(o, "default", { enumerable: true, value: v });
+        Object.defineProperty(o, "default", { enumerable: true, configurable: true, value: v });
     }) : function(o, v) {
         o["default"] = v;
     };


### PR DESCRIPTION
This is the companion PR to microsoft/TypeScript#57784 which improves compatibility with Jest's module mocking mechanism.