### PR TITLE
fix: apply freezing to template object

### DIFF
--- a/tslib.js
+++ b/tslib.js
@@ -303,6 +303,7 @@ var __rewriteRelativeImportExtension;
 
     __makeTemplateObject = function (cooked, raw) {
         if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+        if (Object.freeze) { Object.freeze(cooked); Object.freeze(raw) }
         return cooked;
     };
 


### PR DESCRIPTION
This PR makes generated template string literals follow the ECMA-262 spec.
* https://tc39.es/ecma262/#sec-gettemplateobject
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals