### PR TITLE
remove empty line in __addDisposableResource

### DIFF
--- a/tslib.es6.js
+++ b/tslib.es6.js
@@ -323,7 +323,6 @@ export function __addDisposableResource(env, value, async) {
         env.stack.push({ async: true });
     }
     return value;
-
 }
 
 var _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {


### PR DESCRIPTION
Thanks for providing such a runtime library that enables the use of many modern JS features like `using`. This empty line is found when I checked my output of JS bundle and the line only appears in file `tslib.es6.js`. That is why I open this PR.