### PR TITLE
Enable trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -28,6 +29,5 @@ jobs:
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org/
+      - run: npm install -g npm@latest
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
In light of recent malicious attacks,

This PR edits your `publish.yaml` to switch to Trusted Publishing. It lets your CI (e.g., GitHub Actions) mint a short‑lived OIDC ID token (`permissions: id-token: write`) that npm exchanges for a publish credential at runtime, so you don’t have to store long‑lived npm tokens in CI. npm CLI 11.5.1+ is required, and when you publish public packages from public repos npm will automatically attach provenance attestations. Don’t forget to enable a Trusted Publisher for your package in the npmjs.com settings.

See:

https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/

https://docs.npmjs.com/trusted-publishers

Also. If it is already not set, please switch the package's Publishing Access radio button to "Require two-factor authentication and disallow tokens".
