### PR TITLE
feat(exports): Add support for react-native conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "sideEffects": false,
     "exports": {
         ".": {
+            "react-native": {
+                "types": "./modules/index.d.ts",
+                "default": "./tslib.es6.mjs"
+            },
             "module": {
                 "types": "./modules/index.d.ts",
                 "default": "./tslib.es6.mjs"


### PR DESCRIPTION
In the exports field of package.json, a react-native conditional export has been added for the "." entry, pointing to ./modules/index.d.ts (types) and ./tslib.es6.mjs (default).